### PR TITLE
Improve PHPUnit namespace and fixture methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,13 @@
       "Weibo\\": "src/Weibo/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Weibo\\tests\\": "tests/"
+    }
+  },
   "require": {
+    "php": ">=5.6",
     "ext-dom": "*",
     "ext-libxml": "*",
     "ext-simplexml": "*",

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -11,7 +11,9 @@ use Weibo\Exception\WeiboException;
 use Weibo\Hydrator\Feed;
 use Weibo\Hydrator\Item;
 
-class ApiTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ApiTest extends TestCase
 {
     /**
      * @var Client
@@ -23,7 +25,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
      */
     private $invalidClient;
 
-    public function setUp()
+    protected function setUp()
     {
         $validFixtures = file_get_contents(__DIR__ . '/fixtures/valid_rss.xml');
 


### PR DESCRIPTION
# Changed log

- Using the `PHPUnit\Framework\TestCase` namespace to be easy to migrate to new PHPUnit version.
- According to the `.travis.yml` file, it should let this pakcage require `php-5.6` version at least.
- According to the [PHPUnit fixtures reference](https://phpunit.de/manual/5.7/en/fixtures.html#fixtures.more-setup-than-teardown), it should be the `protected function setUp()` method.